### PR TITLE
Add support for version 1.x of paymenter

### DIFF
--- a/HestiaCP/HestiaCP.php
+++ b/HestiaCP/HestiaCP.php
@@ -1,11 +1,13 @@
 <?php
 
-namespace App\Extensions\Servers\HestiaCP;
+namespace Paymenter\Extensions\Servers\HestiaCP;
 
-use App\Classes\Extensions\Server;
-use App\Helpers\ExtensionHelper;
+use App\Classes\Extension\Server;
+use App\Models\Service;
+use App\Rules\Domain;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
+
 
 class HestiaCP extends Server
 {
@@ -21,150 +23,215 @@ class HestiaCP extends Server
 
     private function request($data = [])
     {
-        $host = rtrim(ExtensionHelper::getConfig('HestiaCP', 'host'), '/');
-        $port = rtrim(ExtensionHelper::getConfig('HestiaCP', 'port'), '/');
-        $accesskey = ExtensionHelper::getConfig('HestiaCP', 'accesskey'); 
-        $secretkey = ExtensionHelper::getConfig('HestiaCP', 'secretkey'); 
+        $host = rtrim($this->config('host'), '/');
+        $port = rtrim($this->config('port'), '/');
+        $accesskey = $this->config('accesskey');
+        $secretkey = $this->config('secretkey');
 
-        $data['hash'] = $accesskey.':'.$secretkey;
-
-        $response = Http::post($host . ':'. $port . '/api/', $data);
+        $data['hash'] = $accesskey . ':' . $secretkey;
+        $response = Http::post($host . ':' . $port . '/api/', $data);
         if ($response->failed()) {
             dd($response->body(), $response->status());
             throw new \Exception('Error while requesting API');
         }
+
         return $response;
     }
 
-    public function getConfig()
+    public function getConfig($values = [])
     {
         return [
             [
                 'name' => 'host',
                 'type' => 'text',
-                'friendlyName' => 'Hostname',
+                'label' => 'Hostname',
                 'validation' => 'url:http,https',
                 'required' => true,
             ],
             [
                 'name' => 'port',
                 'type' => 'text',
-                'friendlyName' => 'Port',
+                'label' => 'Port',
                 'validation' => 'numeric',
                 'required' => true,
             ],
             [
                 'name' => 'accesskey',
                 'type' => 'text',
-                'friendlyName' => 'Access Key',
+                'label' => 'Access Key ID',
                 'required' => true,
             ],
             [
                 'name' => 'secretkey',
                 'type' => 'text',
-                'friendlyName' => 'Secret key',
+                'label' => 'Secret key',
                 'required' => true,
             ],
         ];
     }
-    
+
     public function getProductConfig($options)
     {
         // Get all the packages
-        $response = $this->request(['cmd' => 'v-list-user-packages', 'arg1' => 'json']); 
+        $response = $this->request(['cmd' => 'v-list-user-packages', 'arg1' => 'json']);
         $packages = $response->json();
         $packageOptions = [];
         foreach ($packages as $package => $options) {
-            $packageOptions[] = [
-                'value' => $package,
-                'name' => $package,
-            ];
+            $packageOptions[$package] = $package;
         }
 
         return [
             [
                 'name' => 'package',
-                'type' => 'dropdown',
-                'friendlyName' => 'Package',
+                'type' => 'select',
+                'label' => 'Package',
                 'options' => $packageOptions,
                 'required' => true,
             ],
         ];
     }
 
-    public function getUserConfig()
+    public function getCheckoutConfig()
     {
         return [
             [
                 'name' => 'domain',
                 'type' => 'text',
-                'validation' => 'domain',
-                'friendlyName' => 'Domain',
+                'validation' => [new Domain, 'required'],
+                'label' => 'Domain',
+                'placeholder' => 'domain.com',
                 'required' => true,
             ]
         ];
     }
 
-    public function createServer($user, $params, $order, $orderProduct, $configurableOptions)
+    /**
+     * Generate a random string, using a cryptographically secure 
+     * pseudorandom number generator (random_int)
+     * 
+     * For PHP 7, random_int is a PHP core function
+     * For PHP 5.x, depends on https://github.com/paragonie/random_compat
+     * 
+     * @param int $length      How many characters do we want?
+     * @param string $keyspace A string of all possible characters
+     *                         to select from
+     * @return string
+     */
+    private static function random_str(
+        $length,
+        $keyspace = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+    ) {
+        $str = '';
+        $max = mb_strlen($keyspace, '8bit') - 1;
+        if ($max < 1) {
+            throw new Exception('$keyspace must be at least two characters long');
+        }
+        for ($i = 0; $i < $length; ++$i) {
+            $str .= $keyspace[random_int(0, $max)];
+        }
+        return $str;
+    }
+
+    public function createServer(Service $service, $settings, $properties)
     {
         $username = strtolower(Str::random());
-        $password = Str::random();
+        $password = self::random_str(16);
+
         // If first one is a number, add a letter
         if (is_numeric($username[0])) {
             $username = 'a' . substr($username, 1);
         }
+
         $this->request([
-            'cmd' => 'v-add-user', 
+            'cmd' => 'v-add-user',
             'arg1' => $username,
             'arg2' => $password,
-            'arg3' => $user->email,
-            'arg4' => $params['package'],
-            'arg5' => $user -> name,
+            'arg3' => $service->user->email,
+            'arg4' => $settings['package'],
+            'arg5' => explode('@', $service->user->email)[0],
         ]);
 
-        $this -> request([
-            'cmd' => 'v-add-domain', 
+        $this->request([
+            'cmd' => 'v-add-domain',
             'arg1' => $username,
-            'arg2' => $params['config']['domain'],
+            'arg2' => $properties['domain'],
         ]);
 
-        ExtensionHelper::setOrderProductConfig('username', strtolower($username), $orderProduct->id);
-        ExtensionHelper::setOrderProductConfig('password', $password, $orderProduct->id);
-        
+        $service->properties()->updateOrCreate([
+            'key' => 'hestiacp_username',
+        ], [
+            'name' => 'HestiaCP Username',
+            'value' => strtolower($username),
+        ]);
+
+        $service->properties()->updateOrCreate([
+            'key' => 'hestiacp_password',
+        ], [
+            'name' => 'HestiaCP Password',
+            'value' => $password,
+        ]);
+
+
         return true;
     }
 
-    public function suspendServer($user, $params, $order, $orderProduct, $configurableOptions)
+    public function suspendServer(Service $service, $settings, $properties)
     {
+        if (!isset($properties['hestiacp_username'])) {
+            throw new \Exception("Service has not been created");
+        }
+
         $this->request([
-            'cmd' => 'v-suspend-user', 
-            'arg1' => $params['config']['username'],
+            'cmd' => 'v-suspend-user',
+            'arg1' => $properties['hestiacp_username'],
         ]);
 
         return true;
     }
 
-    public function unsuspendServer($user, $params, $order, $orderProduct, $configurableOptions)
+    public function unsuspendServer(Service $service, $settings, $properties)
     {
-       
+        if (!isset($properties['hestiacp_username'])) {
+            throw new \Exception("Service has not been created");
+        }
+
         $this->request([
-            'cmd' => 'v-unsuspend-user', 
-            'arg1' => $params['config']['username'],
+            'cmd' => 'v-unsuspend-user',
+            'arg1' => $properties['hestiacp_username'],
         ]);
 
         return true;
     }
 
-    public function terminateServer($user, $params, $order, $orderProduct, $configurableOptions)
+    public function terminateServer(Service $service, $settings, $properties)
     {
-        
+        if (!isset($properties['hestiacp_username'])) {
+            throw new \Exception("Service has not been created");
+        }
+
         $this->request([
-            'cmd' => 'v-delete-user', 
-            'arg1' => $params['config']['username'],
+            'cmd' => 'v-delete-user',
+            'arg1' => $properties['hestiacp_username'],
         ]);
+
+        $service->properties()->where('key', 'hestiacp_username')->delete();
+        $service->properties()->where('key', 'hestiacp_password')->delete();
 
         return true;
     }
-    
 
+    public function getActions(Service $service, $settings, $properties): array
+    {
+        if (!isset($properties['hestiacp_username'])) {
+            return [];
+        }
+
+        return [
+            [
+                'type' => 'button',
+                'url' => $this->config('host') . ':' . $this->config('port'),
+                'label' => 'Go to Control Panel',
+            ]
+        ];
+    }
 }


### PR DESCRIPTION
Fixed all problems with Paymenter 1.x version.
There is still no option for `upgradeServer`, and you can't see the login details in the `Product Details`.
But it works.

Fixed #1 